### PR TITLE
fixed api color and link

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -260,7 +260,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     //@RequiresApi(Build.VERSION_CODES.O)
     override fun onMapReady(googleMap: GoogleMap) {
         mMap = googleMap
-        val currentAPI = 69
+        val currentAPI = 0
         val APIMatch = APIVersionMatch(currentAPI, "https://shuttletracker.app/version")
         if(APIMatch) {
             drawStops("https://shuttletracker.app/stops")

--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -260,7 +260,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     //@RequiresApi(Build.VERSION_CODES.O)
     override fun onMapReady(googleMap: GoogleMap) {
         mMap = googleMap
-        val currentAPI = 0
+        val currentAPI = 69
         val APIMatch = APIVersionMatch(currentAPI, "https://shuttletracker.app/version")
         if(APIMatch) {
             drawStops("https://shuttletracker.app/stops")
@@ -284,7 +284,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
                 .setPositiveButton("Update") { dialog, which ->
                     val browserIntent = Intent(
                         Intent.ACTION_VIEW,
-                        Uri.parse("http://www.google.com")
+                        Uri.parse("https://play.google.com/store/apps/details?id=com.duckduckgo.mobile.android&hl=en_US&gl=US")
                     )
                     startActivity(browserIntent)
                 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#FF0000</color>
+    <color name="colorPrimary">#616161</color>
     <color name="colorPrimaryDark">#000000</color>
     <color name="colorAccent">#FF0000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,7 +5,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="colorSurface">@color/colorPrimaryDark</item>
+        <item name="colorSurface">@color/colorPrimary</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Changed the API dialog surface color to a grey (works for users in both light and dark mode, also matches school colors), and changed link to DuckDuckGo until beta.