### PR TITLE
Change all respective `LinearLayout`s to FABs

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -36,10 +36,10 @@ import android.system.Os.accept
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.android.synthetic.main.activity_maps.fabBGLayout
 import kotlinx.android.synthetic.main.activity_maps.fab
-import kotlinx.android.synthetic.main.activity_maps.fabLayout1
-import kotlinx.android.synthetic.main.activity_maps.fabLayout2
-import kotlinx.android.synthetic.main.activity_maps.fabLayout3
-import kotlinx.android.synthetic.main.activity_maps.fabLayout4
+import kotlinx.android.synthetic.main.activity_maps.fab1
+import kotlinx.android.synthetic.main.activity_maps.fab2
+import kotlinx.android.synthetic.main.activity_maps.fab3
+import kotlinx.android.synthetic.main.activity_maps.fab4
 import android.animation.Animator
 import android.app.Application
 import android.content.Context
@@ -109,16 +109,16 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     }
 
     private fun showFABMenu() {
-        fabLayout1.visibility = View.VISIBLE
-        fabLayout2.visibility = View.VISIBLE
-        fabLayout3.visibility = View.VISIBLE
+        fab1.visibility = View.VISIBLE
+        fab2.visibility = View.VISIBLE
+        fab3.visibility = View.VISIBLE
         //fablayout4 (the refresh button) is already visible at the start
         fabBGLayout.visibility = View.VISIBLE
         fab.animate().rotationBy(180F)
-        fabLayout1.animate().translationY(-resources.getDimension(R.dimen.standard_75))
-        fabLayout2.animate().translationY(-resources.getDimension(R.dimen.standard_135))
-        fabLayout3.animate().translationY(-resources.getDimension(R.dimen.standard_215))
-        fabLayout4.animate().translationY(-resources.getDimension(R.dimen.standard_210))
+        fab1.animate().translationY(-resources.getDimension(R.dimen.standard_75))
+        fab2.animate().translationY(-resources.getDimension(R.dimen.standard_135))
+        fab3.animate().translationY(-resources.getDimension(R.dimen.standard_215))
+        fab4.animate().translationY(-resources.getDimension(R.dimen.standard_210))
         var btn_info = findViewById(R.id.fab3) as FloatingActionButton
         btn_info.bringToFront()
     }
@@ -127,17 +127,17 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         fabBGLayout.visibility = View.GONE
         fab.bringToFront()
         fab.animate().rotation(0F)
-        fabLayout1.animate().translationY(0f)
-        fabLayout2.animate().translationY(0f)
-        fabLayout3.animate().translationY(0f)
-        fabLayout4.animate().translationY(0f)
+        fab1.animate().translationY(0f)
+        fab2.animate().translationY(0f)
+        fab3.animate().translationY(0f)
+        fab4.animate().translationY(0f)
             .setListener(object : Animator.AnimatorListener {
                 override fun onAnimationStart(animator: Animator) {}
                 override fun onAnimationEnd(animator: Animator) {
                     if (View.GONE == fabBGLayout.visibility) {
-                        fabLayout1.visibility = View.GONE
-                        fabLayout2.visibility = View.GONE
-                        fabLayout3.visibility = View.GONE
+                        fab1.visibility = View.GONE
+                        fab2.visibility = View.GONE
+                        fab3.visibility = View.GONE
                     }
                 }
 

--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -120,7 +120,6 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         fabLayout3.animate().translationY(-resources.getDimension(R.dimen.standard_215))
         fabLayout4.animate().translationY(-resources.getDimension(R.dimen.standard_210))
         var btn_info = findViewById(R.id.fab3) as FloatingActionButton
-        //        var btn_refresh = findViewById(R.id.fab4) as FloatingActionButton
         btn_info.bringToFront()
     }
 

--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -88,9 +88,9 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         fabBGLayout.setOnClickListener { closeFABMenu() }
-        var btn_settings = findViewById(R.id.fabLayout1) as LinearLayout
-        var btn_about = findViewById(R.id.fabLayout2) as LinearLayout
-        var btn_info = findViewById(R.id.fabLayout3) as LinearLayout
+        var btn_settings = findViewById(R.id.fab1) as FloatingActionButton
+        var btn_about = findViewById(R.id.fab2) as FloatingActionButton
+        var btn_info = findViewById(R.id.fab3) as FloatingActionButton
 
 
         btn_settings.setOnClickListener {
@@ -119,7 +119,8 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         fabLayout2.animate().translationY(-resources.getDimension(R.dimen.standard_135))
         fabLayout3.animate().translationY(-resources.getDimension(R.dimen.standard_215))
         fabLayout4.animate().translationY(-resources.getDimension(R.dimen.standard_210))
-        var btn_info = findViewById(R.id.fabLayout3) as LinearLayout
+        var btn_info = findViewById(R.id.fab3) as FloatingActionButton
+        //        var btn_refresh = findViewById(R.id.fab4) as FloatingActionButton
         btn_info.bringToFront()
     }
 

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -4,11 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/map"
     android:name="com.google.android.gms.maps.SupportMapFragment"
-    android:configChanges="uiMode"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MapsActivity"
-    >
+    android:configChanges="uiMode"
+    tools:context=".MapsActivity">
 
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -20,8 +19,7 @@
 
         <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            >
+            android:layout_height="wrap_content">
 
 
         </com.google.android.material.appbar.AppBarLayout>
@@ -34,132 +32,75 @@
             android:layout_height="match_parent"
             android:visibility="gone" />
 
-        <LinearLayout
-            android:id="@+id/fabLayout1"
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_margin="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="39dp"
+            android:layout_marginBottom="44dp"
             android:clipToPadding="false"
             android:gravity="center_vertical"
-            android:visibility="gone">
+            android:src="@drawable/ic_settings"
+            app:fabSize="mini" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                 />
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="23dp"
-                android:layout_marginBottom="28dp"
-                app:fabSize="mini"
-                android:layout_gravity="bottom|end"
-                android:gravity="center_vertical"
-                android:src="@drawable/ic_settings" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/fabLayout2"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_margin="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="39dp"
+            android:layout_marginBottom="48dp"
             android:clipToPadding="false"
             android:gravity="center_vertical"
-            android:visibility="gone">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                />
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="23dp"
-                android:layout_marginBottom="28dp"
-                app:fabSize="mini"
-                android:layout_gravity="bottom|end"
-                android:gravity="center_vertical"
-                android:src="@drawable/ic_baseline_more_24"/>
-        </LinearLayout>
+            android:src="@drawable/ic_baseline_more_24"
+            android:visibility="gone"
+            app:fabSize="mini" />
 
 
-        <LinearLayout
-            android:id="@+id/fabLayout3"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_marginRight="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="39dp"
+            android:layout_marginBottom="28dp"
             android:clipToPadding="false"
             android:gravity="center_vertical"
-            android:visibility="gone">
+            android:src="@drawable/ic_baseline_info_24"
+            android:visibility="gone"
+            app:fabSize="mini" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                />
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab3"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="23dp"
-                android:layout_marginBottom="28dp"
-                app:fabSize="mini"
-                android:layout_gravity="bottom|end"
-                android:gravity="center_vertical"
-                android:src="@drawable/ic_baseline_info_24" />
-        </LinearLayout>
-        <LinearLayout
-            android:id="@+id/fabLayout4"
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_margin="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginRight="39dp"
+            android:layout_marginBottom="100dp"
             android:clipToPadding="false"
             android:gravity="center_vertical"
-            >
+            android:src="@drawable/ic_baseline_refresh_24"
+            app:fabSize="mini" />
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                />
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab4"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="23dp"
-                android:layout_marginBottom="84dp"
-                app:fabSize="mini"
-                android:layout_gravity="bottom|end"
-                android:gravity="center_vertical"
-                android:src="@drawable/ic_baseline_refresh_24" />
-        </LinearLayout>
-
-        <LinearLayout
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_margin="16dp"
-            android:clipToPadding="false"
+            android:layout_margin="32dp"
             android:gravity="center_vertical"
-            >
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="bottom|end"
-                android:gravity="center_vertical"
-                android:layout_margin="16dp"
-                android:src="@drawable/ic_menu_hamburger" />
-        </LinearLayout>
+            android:src="@drawable/ic_menu_hamburger" />
 
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Adhered to proper android coding practices and changed all LinearLayouts into FloatingActionButtons. This also fixed the animation for opening the FAB menu as before the animation used to appear on top of the menu, but now opens from under it. Closes #39 