### PR TITLE
Added feature to change server URL in-app

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/AnnouncementsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/AnnouncementsActivity.kt
@@ -1,4 +1,7 @@
 package edu.rpi.shuttletracker
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Resources
 import android.os.Bundle
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -17,7 +20,10 @@ class AnnouncementsActivity : AppCompatActivity(){
         setContentView(R.layout.activity_announcements)
         val thread = Thread(kotlinx.coroutines.Runnable {
             kotlin.run {
-                val announ = URL("https://shuttletracker.app/announcements")
+                val sharedPreferences: SharedPreferences =
+                    getSharedPreferences("preferences", Context.MODE_PRIVATE)
+                val server_url = sharedPreferences.getString("server_base_url", resources.getString(R.string.default_server_url))
+                val announ = URL(server_url + resources.getString(R.string.announcements_url))
                 var announString = announ.readText()
                 val announArray = JSONArray(announString)
                 val currentDate: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)

--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -114,6 +114,9 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     //private var longitude: Float? = null
     private var type = "user"
     private lateinit var date: String
+//
+//    private val sharedPreferences: SharedPreferences =
+//        getSharedPreferences("preferences", Context.MODE_PRIVATE)
 
     var wakelockIntent = Intent(this, Wakelock::class.java)
 
@@ -550,12 +553,15 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onResume() {
         super.onResume()
         val res : Resources = getResources()
+        val sharedPreferences: SharedPreferences =
+            getSharedPreferences("preferences", Context.MODE_PRIVATE)
+        val server_url = sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url))
         if(internet_connection())
         {
             busMarkerArray = if(!busesDrawn) {
-                 drawBuses(res.getString(R.string.buses_url))
+                 drawBuses(server_url + res.getString(R.string.buses_url))
             } else{
-                 updateBuses(res.getString(R.string.buses_url), busMarkerArray)
+                 updateBuses(server_url + res.getString(R.string.buses_url), busMarkerArray)
             }
         }
     }
@@ -938,6 +944,12 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         val boardBusButton = findViewById<Button>(R.id.board_bus_button)
         val leaveBusButton = findViewById<Button>(R.id.leave_bus_button)
 
+        val res: Resources = getResources()
+
+        val sharedPreferences: SharedPreferences =
+            getSharedPreferences("preferences", Context.MODE_PRIVATE)
+        val server_url = sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url))
+
         mMap = googleMap
         mMap.getUiSettings().setMapToolbarEnabled(false)
         val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
@@ -956,8 +968,6 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         mMap.setMinZoomPreference(13.5f)
         mMap.setMaxZoomPreference(20.0f)
         mMap.moveCamera(CameraUpdateFactory.newLatLng(Union))
-        val res: Resources = getResources()
-
 
 //        if(APIMatch) {
 
@@ -1015,7 +1025,7 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         } else {
             //Internet connection confirmed, matching API
             APImatch = APIVersionMatch(
-                res.getString(R.string.version_url),
+                server_url + res.getString(R.string.version_url),
                 res.getInteger(R.integer.api_key)
             )
             if (!APImatch) {
@@ -1023,22 +1033,22 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
                 //runOnUiThread { promptDownload() }
             }
         }
-        val sharedPreferences: SharedPreferences =
-            this.getSharedPreferences("preferences", Context.MODE_PRIVATE)
+//        val sharedPreferences: SharedPreferences =
+//            this.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         if (sharedPreferences.contains("toggle_value")) {
             MapsActivity.colorblindMode.setMode(sharedPreferences.getBoolean("toggle_value", true))
         }
         if (internet_connection() && APImatch) {//TODO:make sure the stops and routes are only draw once
 
-            stopArray = drawStops(res.getString(R.string.stops_url))
-            drawRoutes(res.getString(R.string.routes_url))
+            stopArray = drawStops(server_url + res.getString(R.string.stops_url))
+            drawRoutes(server_url + res.getString(R.string.routes_url))
         }
         val busTimer = Timer("busTimer", true)
         val markerTimer = Timer("markerTimer",true)
 
         if (APImatch){
             if (!busesDrawn) {//TODO: bandage for now
-                busMarkerArray = drawBuses(res.getString(R.string.buses_url))
+                busMarkerArray = drawBuses(server_url + res.getString(R.string.buses_url))
             }
         }
 
@@ -1054,10 +1064,10 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         busTimer.scheduleAtFixedRate(0, 5000) {
             //if(APIMatch)
             if(internet_connection() && APImatch) {//make sure it would run only when connected to internet and after api check
-                busMarkerArray = updateBuses(res.getString(R.string.buses_url), busMarkerArray)
+                busMarkerArray = updateBuses(server_url + res.getString(R.string.buses_url), busMarkerArray)
                 if(!routeDrawn){
-                    stopArray = drawStops(res.getString(R.string.stops_url))
-                    drawRoutes(res.getString(R.string.routes_url))
+                    stopArray = drawStops(server_url + res.getString(R.string.stops_url))
+                    drawRoutes(server_url + res.getString(R.string.routes_url))
                 }
             }
             //println("Updated bus locations.")
@@ -1090,12 +1100,12 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
                         promptDownload()
                     }
                 if(!routeDrawn){
-                    stopArray = drawStops(res.getString(R.string.stops_url))
-                    drawRoutes(res.getString(R.string.routes_url))
+                    stopArray = drawStops(server_url + res.getString(R.string.stops_url))
+                    drawRoutes(server_url + res.getString(R.string.routes_url))
                 }
                 btn_refresh.startAnimation(rotate)
                 Toast.makeText(applicationContext, "Refreshed!", Toast.LENGTH_SHORT).show()
-                busMarkerArray = updateBuses(res.getString(R.string.buses_url), busMarkerArray)
+                busMarkerArray = updateBuses(server_url + res.getString(R.string.buses_url), busMarkerArray)
             }else {
                 offline_check()
             }

--- a/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/MapsActivity.kt
@@ -114,9 +114,6 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
     //private var longitude: Float? = null
     private var type = "user"
     private lateinit var date: String
-//
-//    private val sharedPreferences: SharedPreferences =
-//        getSharedPreferences("preferences", Context.MODE_PRIVATE)
 
     private lateinit var wakelockIntent: Intent
 
@@ -403,8 +400,11 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
                             getCurrentFormattedDate()
                         )
                         println("parsed JSONObject: $boardBusJSONObject") // TODO: remove/comment this testing clause
+                        val sharedPreferences: SharedPreferences =
+                            getSharedPreferences("preferences", Context.MODE_PRIVATE)
+                        val server_url = sharedPreferences.getString("server_base_url", resources.getString(R.string.default_server_url))
                         val boardBusUrl =
-                            URL(resources.getString(R.string.buses_url) + "/$selectedBusNumber")
+                            URL(server_url + resources.getString(R.string.buses_url) + "/$selectedBusNumber")
                         println("Target URL: $boardBusUrl") // TODO: remove/comment this testing clause
 
                         // send to server
@@ -445,7 +445,10 @@ class MapsActivity : AppCompatActivity(), OnMapReadyCallback {
         val thread = Thread {
             kotlin.run {
                 try {
-                    val url = URL(resources.getString(R.string.bus_numbers_url))
+                    val sharedPreferences: SharedPreferences =
+                        getSharedPreferences("preferences", Context.MODE_PRIVATE)
+                    val server_url = sharedPreferences.getString("server_base_url", resources.getString(R.string.default_server_url))
+                    val url = URL(server_url + resources.getString(R.string.bus_numbers_url))
                     val jsonString = url.readText()
                     val jsonArray = JSONArray(jsonString)
                     for (i in 0 until jsonArray.length()) {

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.google.android.material.switchmaterial.SwitchMaterial
@@ -121,6 +122,10 @@ public class SettingsActivity: AppCompatActivity() {
             context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
         editor.putString("server_base_url", serverURL).apply()
+        val text = "Saved URL"
+        val duration = Toast.LENGTH_SHORT
+        val toast = Toast.makeText(applicationContext, text, duration)
+        toast.show()
 //        val string1 = sharedPreferences.getString("server_base_url", "NOT SPECIFIED")
 //        if (string1 != null) {
 //            Log.d("server_save_button", string1)

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -56,8 +56,14 @@ public class SettingsActivity: AppCompatActivity() {
         serverURLText.setText(sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url)))
         val saveServerURLButton = findViewById<Button>(R.id.saveURLButton)
 
+        val resetURLButton = findViewById<Button>(R.id.resetURLButton)
+
         saveServerURLButton.setOnClickListener {
             saveServerURL(this)
+        }
+
+        resetURLButton.setOnClickListener{
+            resetServerURL(this)
         }
 
         if(sharedPreferences.contains("toggle_value")) {
@@ -125,29 +131,25 @@ public class SettingsActivity: AppCompatActivity() {
         val serverURLText = findViewById<EditText>(R.id.editServerURL)
         val serverURL = serverURLText.text.toString()
 
-//        Log.d("server_save_button", "msg 1 " + serverURL)
-
         val sharedPreferences: SharedPreferences =
             context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
         editor.putString("server_base_url", serverURL).apply()
 
-        val res: Resources = getResources()
-        val server_url = sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url))
-        if (server_url != null) {
-            Log.d("server_save_button", server_url)
-        }
-
-
         val text = "Saved URL"
         val duration = Toast.LENGTH_SHORT
         val toast = Toast.makeText(applicationContext, text, duration)
         toast.show()
-//        val string1 = sharedPreferences.getString("server_base_url", "NOT SPECIFIED")
-//        if (string1 != null) {
-//            Log.d("server_save_button", string1)
-//        }
-
     }
 
+    private fun resetServerURL(context: Context){
+        val sharedPreferences: SharedPreferences =
+            context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
+        val res: Resources = getResources()
+        val editor = sharedPreferences.edit()
+        editor.putString("server_base_url", res.getString(R.string.default_server_url)).apply()
+        val serverURLText = findViewById<EditText>(R.id.editServerURL)
+        serverURLText.setText(sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url)))
+    }
+    
 }

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -127,7 +127,6 @@ public class SettingsActivity: AppCompatActivity() {
     }
 
     private fun saveServerURL(context: Context) {
-        Log.d("server_save_button", "saveServerURL called")
         val serverURLText = findViewById<EditText>(R.id.editServerURL)
         val serverURL = serverURLText.text.toString()
 
@@ -150,6 +149,11 @@ public class SettingsActivity: AppCompatActivity() {
         editor.putString("server_base_url", res.getString(R.string.default_server_url)).apply()
         val serverURLText = findViewById<EditText>(R.id.editServerURL)
         serverURLText.setText(sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url)))
+
+        val text = "Reset URL"
+        val duration = Toast.LENGTH_SHORT
+        val toast = Toast.makeText(applicationContext, text, duration)
+        toast.show()
     }
-    
+
 }

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.view.MenuItem
+import android.widget.EditText
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -34,9 +35,18 @@ public class SettingsActivity: AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.settings)
 //        drawBusIcons()
-        val toggle: SwitchMaterial = findViewById(R.id.colorblindSwitch)
+
         val sharedPreferences: SharedPreferences =
             this.getSharedPreferences("preferences", Context.MODE_PRIVATE)
+
+        val toggle: SwitchMaterial = findViewById(R.id.colorblindSwitch)
+
+        var serverURLText = findViewById<EditText>(R.id.editServerURL)
+        val message = serverURLText.text.toString()
+        serverURLText.setOnClickListener {
+            saveServerURL(this)
+        }
+
         if(sharedPreferences.contains("toggle_value")) {
             toggle.setChecked(loadToggle(this))
         }
@@ -96,5 +106,10 @@ public class SettingsActivity: AppCompatActivity() {
             context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         return sharedPreferences.getBoolean("toggle_value", true)
     }
+
+    private fun saveServerURL(context: Context) {
+
+    }
+
 
 }

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -112,13 +112,19 @@ public class SettingsActivity: AppCompatActivity() {
 
     private fun saveServerURL(context: Context) {
         Log.d("server_save_button", "saveServerURL called")
-
         val serverURLText = findViewById<EditText>(R.id.editServerURL)
         val serverURL = serverURLText.text.toString()
+
+//        Log.d("server_save_button", "msg 1 " + serverURL)
+
         val sharedPreferences: SharedPreferences =
             context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
         editor.putString("server_base_url", serverURL).apply()
+//        val string1 = sharedPreferences.getString("server_base_url", "NOT SPECIFIED")
+//        if (string1 != null) {
+//            Log.d("server_save_button", string1)
+//        }
 
     }
 

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -2,6 +2,7 @@ package edu.rpi.shuttletracker;
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.res.Resources
 import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.util.Log
@@ -14,6 +15,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.android.synthetic.main.activity_maps.*
+
 
 
 public class SettingsActivity: AppCompatActivity() {
@@ -34,6 +36,11 @@ public class SettingsActivity: AppCompatActivity() {
 //        bMap = BitmapFactory.decodeFile(getString(R.string.colorblind_crowdsourced_bus))
 //        cbcrowdbus.setImageBitmap(bMap)
 //    }
+
+//    private var EditText url_settings_view = (EditText) findViewById(r.id.editServerURL);
+
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.settings)
@@ -43,8 +50,10 @@ public class SettingsActivity: AppCompatActivity() {
             this.getSharedPreferences("preferences", Context.MODE_PRIVATE)
 
         val toggle: SwitchMaterial = findViewById(R.id.colorblindSwitch)
+        val res: Resources = getResources()
 
         val serverURLText = findViewById<EditText>(R.id.editServerURL)
+        serverURLText.setText(sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url)))
         val saveServerURLButton = findViewById<Button>(R.id.saveURLButton)
 
         saveServerURLButton.setOnClickListener {
@@ -122,6 +131,14 @@ public class SettingsActivity: AppCompatActivity() {
             context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
         editor.putString("server_base_url", serverURL).apply()
+
+        val res: Resources = getResources()
+        val server_url = sharedPreferences.getString("server_base_url", res.getString(R.string.default_server_url))
+        if (server_url != null) {
+            Log.d("server_save_button", server_url)
+        }
+
+
         val text = "Saved URL"
         val duration = Toast.LENGTH_SHORT
         val toast = Toast.makeText(applicationContext, text, duration)

--- a/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/SettingsActivity.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.util.Log
 import android.view.MenuItem
+import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
@@ -41,9 +43,10 @@ public class SettingsActivity: AppCompatActivity() {
 
         val toggle: SwitchMaterial = findViewById(R.id.colorblindSwitch)
 
-        var serverURLText = findViewById<EditText>(R.id.editServerURL)
-        val message = serverURLText.text.toString()
-        serverURLText.setOnClickListener {
+        val serverURLText = findViewById<EditText>(R.id.editServerURL)
+        val saveServerURLButton = findViewById<Button>(R.id.saveURLButton)
+
+        saveServerURLButton.setOnClickListener {
             saveServerURL(this)
         }
 
@@ -108,8 +111,15 @@ public class SettingsActivity: AppCompatActivity() {
     }
 
     private fun saveServerURL(context: Context) {
+        Log.d("server_save_button", "saveServerURL called")
+
+        val serverURLText = findViewById<EditText>(R.id.editServerURL)
+        val serverURL = serverURLText.text.toString()
+        val sharedPreferences: SharedPreferences =
+            context.getSharedPreferences("preferences", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        editor.putString("server_base_url", serverURL).apply()
 
     }
-
 
 }

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -27,4 +27,15 @@
         app:titleTextColor="#FFFFFF"
         tools:layout_editor_absoluteX="0dp"
         tools:layout_editor_absoluteY="0dp" />
+
+    <EditText
+        android:id="@+id/editServerURL"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:ems="10"
+        android:inputType="text"
+        android:text="Server URL"
+        app:layout_constraintStart_toStartOf="@id/colorblindSwitch"
+        app:layout_constraintTop_toBottomOf="@id/colorblindSwitch" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -54,6 +54,7 @@
          />
 
     <Button
+        android:id="@+id/resetURLButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/editServerURL"

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -43,7 +43,7 @@
         android:id="@+id/saveURLButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="28dp"
+        android:layout_marginStart="24dp"
         android:text="Apply"
         app:layout_constraintLeft_toRightOf="@id/editServerURL"
         app:layout_constraintStart_toEndOf="@id/editServerURL"

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -33,9 +33,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:ems="10"
+        android:ems="12"
         android:inputType="text"
-        android:text="Server Base URL"
+        android:text="https://shuttletracker.app"
         app:layout_constraintStart_toStartOf="@id/colorblindSwitch"
         app:layout_constraintTop_toBottomOf="@id/colorblindSwitch" />
 
@@ -48,4 +48,5 @@
         app:layout_constraintLeft_toRightOf="@id/editServerURL"
         app:layout_constraintStart_toEndOf="@id/editServerURL"
         app:layout_constraintTop_toTopOf="@id/editServerURL" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -35,7 +35,17 @@
         android:layout_marginTop="16dp"
         android:ems="10"
         android:inputType="text"
-        android:text="Server URL"
+        android:text="Server Base URL"
         app:layout_constraintStart_toStartOf="@id/colorblindSwitch"
         app:layout_constraintTop_toBottomOf="@id/colorblindSwitch" />
+
+    <Button
+        android:id="@+id/saveURLButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="28dp"
+        android:text="Apply"
+        app:layout_constraintLeft_toRightOf="@id/editServerURL"
+        app:layout_constraintStart_toEndOf="@id/editServerURL"
+        app:layout_constraintTop_toTopOf="@id/editServerURL" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -28,25 +28,37 @@
         tools:layout_editor_absoluteX="0dp"
         tools:layout_editor_absoluteY="0dp" />
 
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@id/colorblindSwitch"
+        >
+
     <EditText
         android:id="@+id/editServerURL"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_alignParentLeft="true"
+        android:layout_toLeftOf="@+id/saveURLButton"
         android:ems="12"
         android:inputType="text"
-        android:text="https://shuttletracker.app"
-        app:layout_constraintStart_toStartOf="@id/colorblindSwitch"
-        app:layout_constraintTop_toBottomOf="@id/colorblindSwitch" />
+        android:text="https://shuttletracker.app" />
 
     <Button
         android:id="@+id/saveURLButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
+        android:layout_alignParentRight="true"
         android:text="Apply"
-        app:layout_constraintLeft_toRightOf="@id/editServerURL"
-        app:layout_constraintStart_toEndOf="@id/editServerURL"
-        app:layout_constraintTop_toTopOf="@id/editServerURL" />
+         />
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/editServerURL"
+        android:text="RESET SERVER URL"/>
+
+    </RelativeLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="github_button_text">Click to access our GitHub Repository!</string>
     <string name="repo_url">https://github.com/wtg/Shuttle-Tracker-Android</string>
     <string name="default_server_url">https://shuttletracker.app</string>
+    <string name="announcements_url">/announcements</string>
     <string name="version_url">/version</string>
     <string name="buses_url">/buses</string>
     <string name="bus_numbers_url">/buses/all</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,11 +43,12 @@
     <string name="announcements_default_text">No current announcements.</string>
     <string name="github_button_text">Click to access our GitHub Repository!</string>
     <string name="repo_url">https://github.com/wtg/Shuttle-Tracker-Android</string>
-    <string name="version_url">https://shuttletracker.app/version</string>
-    <string name="buses_url">https://shuttletracker.app/buses</string>
-    <string name="bus_numbers_url">https://shuttletracker.app/buses/all</string>
-    <string name="stops_url">https://shuttletracker.app/stops</string>
-    <string name="routes_url">https://shuttletracker.app/routes</string>
+    <string name="default_server_url">https://shuttletracker.app</string>
+    <string name="version_url">/version</string>
+    <string name="buses_url">/buses</string>
+    <string name="bus_numbers_url">/buses/all</string>
+    <string name="stops_url">/stops</string>
+    <string name="routes_url">/routes</string>
     <string name="board_bus_button_text">Board Bus</string>
     <string name="leave_bus_button_text">Leave Bus</string>
     <string name="channel_name">ShuttleTrackerRPI</string>


### PR DESCRIPTION
tl;dr: Added a text box in app settings to set the server URL and reset it to default. closes #73 

Previously, in 'strings.xml' there was a hard coded URL for every single server URL (announcements, buses, etc.); all of which had to be changed in order to test changes in staging. Now there is a base URL and strings to concatenate (shuttletracker.app + /buses) for ever single user. Added a text box in app to allow users to modify the base URL and still allow for proper functionality throughout the app with the string concatenation. 

Used Android 'SharedPreferences' interface to store the base URL and retrieve it anywhere throughout the app. [SharedPreferences ](https://developer.android.com/reference/android/content/SharedPreferences)can store key-value pairs that can be read from anywhere in the code and allows a 'default value' in case the preference has not been changed yet. In settings, a reset button has been added to reset the URL to the default production URL.