### PR TITLE
Refactor map schedule bottom sheet to BottomSheetScaffold

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/data/models/Schedule.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/data/models/Schedule.kt
@@ -11,7 +11,8 @@ data class Schedule(
     @SerializedName("FRIDAY") val friday: String,
     @SerializedName("SATURDAY") val saturday: String,
     @SerializedName("SUNDAY") val sunday: String,
-    // busName -> list of [time, direction]
+    // Map<busName, List<[time, direction]>>
+    // ex. AM WEST Bus 1 -> list of ["7:00 AM", "WEST"]
     @SerializedName("weekday") val weekday: Map<String, List<List<String>>>,
     @SerializedName("saturday") val saturdaySchedule: Map<String, List<List<String>>>,
     @SerializedName("sunday") val sundaySchedule: Map<String, List<List<String>>>,

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
@@ -8,35 +8,40 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Layers
-import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.Layers
 import androidx.compose.material.icons.outlined.LocationDisabled
 import androidx.compose.material.icons.outlined.MyLocation
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -82,6 +87,7 @@ import edu.rpi.shuttletracker.ui.theme.BusColors
 import edu.rpi.shuttletracker.ui.util.CheckResponseError
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Destination<RootGraph>(start = true)
 @Composable
 fun MapsScreen(
@@ -94,9 +100,30 @@ fun MapsScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
 
-    var isBottomSheetOpen by remember { mutableStateOf(false) }
+    val sheetState =
+        rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded,
+        )
+    val scaffoldState = rememberBottomSheetScaffoldState(bottomSheetState = sheetState)
 
-    Scaffold(
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = 160.dp,
+        sheetDragHandle = { BottomSheetDefaults.DragHandle() },
+        sheetContainerColor = MaterialTheme.colorScheme.surface,
+        sheetContent = {
+            val showDetails by remember {
+                derivedStateOf {
+                    scaffoldState.bottomSheetState.targetValue == SheetValue.Expanded ||
+                        scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded
+                }
+            }
+
+            ScheduleSheetContent(
+                mapsUIState = mapsUiState,
+                isExpanded = showDetails,
+            )
+        },
         snackbarHost = {
             // finds errors when requesting data to server
             CheckResponseError(
@@ -109,7 +136,6 @@ fun MapsScreen(
                     viewModel.loadAll()
                 },
             )
-
             SnackbarHost(hostState = snackbarHostState)
         },
     ) { padding ->
@@ -122,20 +148,7 @@ fun MapsScreen(
                 onSettingsClick = { navigator.navigate(SettingsScreenDestination()) },
                 onToggleMapTypeClick = { viewModel.toggleMapType() },
             )
-            BottomSheetPeek(
-                onClick = { isBottomSheetOpen = true },
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(padding)
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-            )
         }
-        ScheduleBottomSheet(
-            isOpen = isBottomSheetOpen,
-            mapsUIState = mapsUiState,
-            onDismiss = { isBottomSheetOpen = false },
-        )
     }
 }
 
@@ -262,6 +275,7 @@ private fun BusMap(
         MapButtonsOverlay(
             modifier =
                 Modifier
+                    .statusBarsPadding()
                     .padding(padding)
                     .padding(horizontal = 10.dp),
             mapLocationEnabled = mapLocationEnabled,
@@ -487,45 +501,42 @@ fun ActionButton(
 }
 
 @Composable
-private fun BottomSheetPeek(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+fun ScheduleSheetContent(
+    mapsUIState: MapsUIState,
+    isExpanded: Boolean,
 ) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        tonalElevation = 6.dp,
-        shadowElevation = 6.dp,
-        onClick = onClick,
+    val schedule = mapsUIState.schedule
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(.86f),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Row(
+        Text(
+            text = stringResource(R.string.union_schedule),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+
+        Text(
+            text = "Chasen stop available M–F, 7:00 AM – 5:30 PM",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        if (isExpanded) {
+            HorizontalDivider(
                 modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    Text(
-                        text = stringResource(R.string.bottom_sheet_peek_title),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                    Text(
-                        text = stringResource(R.string.bottom_sheet_peek_subtitle),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
-                Icon(
-                    imageVector = Icons.Outlined.ExpandLess,
-                    contentDescription = null,
-                )
+                thickness = DividerDefaults.Thickness,
+            )
+
+            if (schedule == null) {
+                EmptyState(R.string.schedule_no_upcoming_today)
+            } else {
+                ScheduleTimesContent(schedule = schedule)
             }
         }
     }

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -28,9 +26,7 @@ import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetValue
@@ -112,7 +108,7 @@ fun MapsScreen(
         sheetDragHandle = { BottomSheetDefaults.DragHandle() },
         sheetContainerColor = MaterialTheme.colorScheme.surface,
         sheetContent = {
-            val showDetails by remember {
+            val showDetails by remember(scaffoldState.bottomSheetState) {
                 derivedStateOf {
                     scaffoldState.bottomSheetState.targetValue == SheetValue.Expanded ||
                         scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded
@@ -120,8 +116,8 @@ fun MapsScreen(
             }
 
             ScheduleSheetContent(
-                mapsUIState = mapsUiState,
-                isExpanded = showDetails,
+                schedule = mapsUiState.schedule,
+                showDetails = showDetails,
             )
         },
         snackbarHost = {
@@ -496,48 +492,6 @@ fun ActionButton(
             elevation = ButtonDefaults.buttonElevation(defaultElevation = 10.dp),
         ) {
             Icon(icon, icon.name)
-        }
-    }
-}
-
-@Composable
-fun ScheduleSheetContent(
-    mapsUIState: MapsUIState,
-    isExpanded: Boolean,
-) {
-    val schedule = mapsUIState.schedule
-
-    Column(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .fillMaxHeight(.86f),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = stringResource(R.string.union_schedule),
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(bottom = 4.dp),
-        )
-
-        Text(
-            text = "Chasen stop available M–F, 7:00 AM – 5:30 PM",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-
-        if (isExpanded) {
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(),
-                thickness = DividerDefaults.Thickness,
-            )
-
-            if (schedule == null) {
-                EmptyState(R.string.schedule_no_upcoming_today)
-            } else {
-                ScheduleTimesContent(schedule = schedule)
-            }
         }
     }
 }

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsScreen.kt
@@ -107,6 +107,7 @@ fun MapsScreen(
         sheetPeekHeight = 160.dp,
         sheetDragHandle = { BottomSheetDefaults.DragHandle() },
         sheetContainerColor = MaterialTheme.colorScheme.surface,
+        sheetShadowElevation = 10.dp,
         sheetContent = {
             val showDetails by remember(scaffoldState.bottomSheetState) {
                 derivedStateOf {
@@ -136,22 +137,20 @@ fun MapsScreen(
         },
     ) { padding ->
 
-        Box(modifier = Modifier.fillMaxSize()) {
-            BusMap(
-                mapsUIState = mapsUiState,
-                padding = padding,
-                onScheduleClick = { navigator.navigate(ScheduleScreenDestination()) },
-                onSettingsClick = { navigator.navigate(SettingsScreenDestination()) },
-                onToggleMapTypeClick = { viewModel.toggleMapType() },
-            )
-        }
+        ShuttleMap(
+            mapsUiState = mapsUiState,
+            padding = padding,
+            onScheduleClick = { navigator.navigate(ScheduleScreenDestination()) },
+            onSettingsClick = { navigator.navigate(SettingsScreenDestination()) },
+            onToggleMapTypeClick = { viewModel.toggleMapType() },
+        )
     }
 }
 
 /**
  * Creates the map displaying everything
  *
- * @param mapsUIState: The UI state of the view from the view-model
+ * @param mapsUiState: The UI state of the view from the view-model
  * @param padding: Padding needed for the map content padding
  * to close/open the stop bottom sheet
  * @param onScheduleClick: Callback invoked when the user taps the Schedule button
@@ -160,8 +159,8 @@ fun MapsScreen(
  *
  * */
 @Composable
-private fun BusMap(
-    mapsUIState: MapsUIState,
+private fun ShuttleMap(
+    mapsUiState: MapsUiState,
     padding: PaddingValues,
     onScheduleClick: () -> Unit,
     onSettingsClick: () -> Unit,
@@ -171,7 +170,7 @@ private fun BusMap(
     val coroutineScope = rememberCoroutineScope()
 
     // can't show current location without location
-    val mapLocationEnabled by remember {
+    val isLocationPermissionGranted by remember {
         mutableStateOf(
             ActivityCompat.checkSelfPermission(
                 context,
@@ -191,7 +190,7 @@ private fun BusMap(
         }
 
     var selectedStop by remember { mutableStateOf<Stop?>(null) }
-    val isDark = mapsUIState.themeMode.isDarkTheme(isSystemInDarkTheme())
+    val isDark = mapsUiState.themeMode.isDarkTheme(isSystemInDarkTheme())
 
     Box(modifier = Modifier.fillMaxSize()) {
         GoogleMap(
@@ -206,10 +205,10 @@ private fun BusMap(
                             LatLng(42.72095724005504, -73.70196321825452),
                             LatLng(42.741173465236876, -73.6543446409232),
                         ),
-                    mapType = mapsUIState.mapType,
+                    mapType = mapsUiState.mapType,
                     isBuildingEnabled = true,
                     minZoomPreference = 14f,
-                    isMyLocationEnabled = mapLocationEnabled,
+                    isMyLocationEnabled = isLocationPermissionGranted,
                     mapStyleOptions =
                         if (isDark) {
                             MapStyleOptions.loadRawResourceStyle(context, R.raw.map_dark)
@@ -225,9 +224,9 @@ private fun BusMap(
                 ),
         ) {
             // creates the stops
-            mapsUIState.routes.forEach { (_, route) ->
+            mapsUiState.routes.forEach { (_, route) ->
                 route.stopDetails.forEach { (_, stop) ->
-                    StopCircle(
+                    StopMarker(
                         stop = stop,
                         selected = stop.name == selectedStop?.name,
                         onSelected = { selectedStop = it },
@@ -236,15 +235,15 @@ private fun BusMap(
             }
 
             // creates the bus markers
-            mapsUIState.buses.forEach {
+            mapsUiState.buses.forEach {
                 BusMarker(
                     bus = it,
-                    colorBlindMode = mapsUIState.colorBlindMode,
+                    colorBlindMode = mapsUiState.colorBlindMode,
                 )
             }
 
             // draws the paths
-            mapsUIState.routes.forEach { (_, route) ->
+            mapsUiState.routes.forEach { (_, route) ->
                 val points = route.latLng()
                 if (points.isNotEmpty()) {
                     Polyline(
@@ -262,7 +261,7 @@ private fun BusMap(
         }
 
         val mapTypeIcon =
-            if (mapsUIState.mapType == MapType.NORMAL) {
+            if (mapsUiState.mapType == MapType.NORMAL) {
                 Icons.Outlined.Layers
             } else {
                 Icons.Filled.Layers
@@ -274,7 +273,7 @@ private fun BusMap(
                     .statusBarsPadding()
                     .padding(padding)
                     .padding(horizontal = 10.dp),
-            mapLocationEnabled = mapLocationEnabled,
+            isMyLocationEnabled = isLocationPermissionGranted,
             mapTypeIcon = mapTypeIcon,
             onScheduleClick = onScheduleClick,
             onSettingsClick = onSettingsClick,
@@ -314,7 +313,7 @@ private fun BusMap(
  * Creates a marker for a stop
  * */
 @Composable
-private fun StopCircle(
+private fun StopMarker(
     stop: Stop,
     selected: Boolean,
     onSelected: (Stop) -> Unit,
@@ -379,13 +378,13 @@ private fun BusMarker(
         }
 
     // gets bus speed and last time it updated
-    val timeBusUpdate = bus.getTimeAgo().collectAsStateWithLifecycle(initialValue = "").value
+    val lastUpdatedAgoText = bus.getTimeAgo().collectAsStateWithLifecycle(initialValue = "").value
     val snippetText =
         buildString {
             append(stringResource(R.string.bus_speed, bus.speedMph))
-            if (timeBusUpdate.isNotBlank()) {
+            if (lastUpdatedAgoText.isNotBlank()) {
                 append(" • ")
-                append(timeBusUpdate)
+                append(lastUpdatedAgoText)
             }
         }
 
@@ -406,7 +405,7 @@ private fun BusMarker(
 @Composable
 private fun MapButtonsOverlay(
     modifier: Modifier = Modifier,
-    mapLocationEnabled: Boolean,
+    isMyLocationEnabled: Boolean,
     mapTypeIcon: ImageVector,
     onScheduleClick: () -> Unit,
     onSettingsClick: () -> Unit,
@@ -416,7 +415,7 @@ private fun MapButtonsOverlay(
     Box(
         modifier = modifier.fillMaxSize(),
     ) {
-        // Left side (Schedule, Settings)
+        // Left side
         Column(
             modifier =
                 Modifier
@@ -431,7 +430,7 @@ private fun MapButtonsOverlay(
                 onSettingsClick()
             }
         }
-        // Right side (Location, Layers)
+        // Right side
         Column(
             modifier =
                 Modifier
@@ -440,7 +439,7 @@ private fun MapButtonsOverlay(
         ) {
             ActionButton(
                 icon =
-                    if (mapLocationEnabled) {
+                    if (isMyLocationEnabled) {
                         Icons.Outlined.MyLocation
                     } else {
                         Icons.Outlined.LocationDisabled
@@ -460,9 +459,8 @@ private fun MapButtonsOverlay(
  * @param badgeCount: if a badge is needed for a item, it will display
  * @param action: what to do on button click
  * */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ActionButton(
+private fun ActionButton(
     icon: ImageVector,
     badgeCount: Int = 0,
     action: () -> Unit,

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsViewModel.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/MapsViewModel.kt
@@ -35,8 +35,8 @@ class MapsViewModel
         private val userPreferencesRepository: UserPreferencesRepository,
     ) : ViewModel() {
         // represents the ui state of the view
-        private val _mapsUiState = MutableStateFlow(MapsUIState())
-        val mapsUiState: StateFlow<MapsUIState> = _mapsUiState
+        private val _mapsUiState = MutableStateFlow(MapsUiState())
+        val mapsUiState: StateFlow<MapsUiState> = _mapsUiState
 
         // shared flow of the running buses, this is to be subscribed to in UI
         lateinit var busesState: SharedFlow<Unit>
@@ -222,7 +222,7 @@ class MapsViewModel
  * Representation of the screen
  * */
 @Immutable
-data class MapsUIState(
+data class MapsUiState(
     val buses: List<Bus> = listOf(),
     val routes: Map<String, Route> = emptyMap(),
     val schedule: Schedule? = null,

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleBottomSheet.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleBottomSheet.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -14,16 +13,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DividerDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,41 +40,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ScheduleBottomSheet(
-    isOpen: Boolean,
-    mapsUIState: MapsUIState,
-    onDismiss: () -> Unit,
-) {
-    if (!isOpen) return
-
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-
-    val schedule = mapsUIState.schedule
-
-    ModalBottomSheet(
-        modifier = Modifier.fillMaxHeight(),
-        sheetState = sheetState,
-        onDismissRequest = onDismiss,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                stringResource(R.string.union_schedule),
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(bottom = 5.dp),
-            )
-
-            schedule?.let { ScheduleTimesContent(schedule = it) }
-        }
-    }
-}
-
-@Composable
-private fun ScheduleTimesContent(schedule: Schedule) {
+fun ScheduleTimesContent(schedule: Schedule) {
     var selectedDay by remember { mutableStateOf(DayOfWeek.fromToday()) }
     var selectedDirection by remember { mutableStateOf<String?>(null) }
 
@@ -198,7 +161,7 @@ private fun ScheduleBody(
 }
 
 @Composable
-private fun EmptyState(textRes: Int) {
+fun EmptyState(textRes: Int) {
     Box(
         Modifier
             .fillMaxWidth()

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
@@ -41,6 +41,8 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
 
+// Header / Peak
+
 @Composable
 fun ScheduleSheetContent(
     schedule: Schedule?,
@@ -75,28 +77,27 @@ fun ScheduleSheetContent(
             if (schedule == null) {
                 EmptyState(R.string.schedule_no_upcoming_today)
             } else {
-                ScheduleTimesContent(schedule = schedule)
+                ScheduleDetailsContent(schedule = schedule)
             }
         }
     }
 }
 
 @Composable
-fun ScheduleTimesContent(schedule: Schedule) {
+private fun ScheduleDetailsContent(schedule: Schedule) {
     var selectedDay by remember { mutableStateOf(DayOfWeek.fromToday()) }
     var selectedDirection by remember { mutableStateOf<String?>(null) }
 
     val directions =
         remember(selectedDay, schedule) {
-            availableDirections(selectedDay, schedule)
+            directionsForDay(selectedDay, schedule)
         }
 
     LaunchedEffect(selectedDay, directions) {
         selectedDirection =
             when {
                 directions.isEmpty() -> null
-                selectedDirection == null -> directions.first()
-                directions.contains(selectedDirection) -> selectedDirection
+                selectedDirection in directions -> selectedDirection
                 else -> directions.first()
             }
     }
@@ -130,6 +131,8 @@ fun ScheduleTimesContent(schedule: Schedule) {
         times = times,
     )
 }
+
+// Selectors
 
 @Composable
 private fun DaySelector(
@@ -170,7 +173,13 @@ private fun RouteSelector(
     ) {
         directions.forEach { dir ->
             RouteTab(
-                label = dir.lowercase().replaceFirstChar { it.uppercase() } + " Route",
+                label =
+                    stringResource(
+                        R.string.route_label_format,
+                        dir
+                            .lowercase()
+                            .replaceFirstChar { it.titlecase() },
+                    ),
                 route = dir,
                 selectedRoute = selectedDirection,
                 onRouteSelected = onSelect,
@@ -179,6 +188,48 @@ private fun RouteSelector(
         }
     }
 }
+
+@Composable
+private fun RouteTab(
+    label: String,
+    route: String,
+    selectedRoute: String?,
+    onRouteSelected: (String) -> Unit,
+    modifier: Modifier,
+) {
+    val selected = route == selectedRoute
+
+    Surface(
+        onClick = { onRouteSelected(route) },
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = if (selected) 2.dp else 0.dp,
+        color =
+            if (selected) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.surfaceVariant
+            },
+        modifier = modifier,
+    ) {
+        Text(
+            text = label,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 10.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.labelLarge,
+            color =
+                if (selected) {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+        )
+    }
+}
+
+// List content
 
 @Composable
 private fun ScheduleBody(
@@ -198,18 +249,6 @@ private fun ScheduleBody(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun EmptyState(textRes: Int) {
-    Box(
-        Modifier
-            .fillMaxWidth()
-            .padding(24.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(stringResource(textRes))
     }
 }
 
@@ -254,6 +293,18 @@ private fun ScheduleTimeRow(
     }
 }
 
+@Composable
+private fun EmptyState(textRes: Int) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(stringResource(textRes))
+    }
+}
+
 private fun busTagColor(
     busName: String,
     defaultColor: Color,
@@ -266,49 +317,9 @@ private fun busTagColor(
     }
 }
 
-@Composable
-private fun RouteTab(
-    label: String,
-    route: String,
-    selectedRoute: String?,
-    onRouteSelected: (String) -> Unit,
-    modifier: Modifier,
-) {
-    val selected = route == selectedRoute
-
-    Surface(
-        onClick = { onRouteSelected(route) },
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = if (selected) 2.dp else 0.dp,
-        color =
-            if (selected) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else {
-                MaterialTheme.colorScheme.surfaceVariant
-            },
-        modifier = modifier,
-    ) {
-        Text(
-            text = label,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 10.dp),
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.labelLarge,
-            color =
-                if (selected) {
-                    MaterialTheme.colorScheme.onPrimaryContainer
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
-        )
-    }
-}
-
 // Data helpers
 
-private fun availableDirections(
+private fun directionsForDay(
     day: DayOfWeek,
     data: Schedule,
 ): List<String> {

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -39,6 +40,46 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Locale
+
+@Composable
+fun ScheduleSheetContent(
+    schedule: Schedule?,
+    showDetails: Boolean,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(.86f),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.bottom_sheet_peek_title),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+
+        Text(
+            text = stringResource(R.string.bottom_sheet_peek_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        if (showDetails) {
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = DividerDefaults.Thickness,
+            )
+
+            if (schedule == null) {
+                EmptyState(R.string.schedule_no_upcoming_today)
+            } else {
+                ScheduleTimesContent(schedule = schedule)
+            }
+        }
+    }
+}
 
 @Composable
 fun ScheduleTimesContent(schedule: Schedule) {
@@ -133,7 +174,7 @@ private fun RouteSelector(
                 route = dir,
                 selectedRoute = selectedDirection,
                 onRouteSelected = onSelect,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).padding(bottom = 8.dp),
             )
         }
     }
@@ -161,7 +202,7 @@ private fun ScheduleBody(
 }
 
 @Composable
-fun EmptyState(textRes: Int) {
+private fun EmptyState(textRes: Int) {
     Box(
         Modifier
             .fillMaxWidth()

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/maps/ScheduleSheetContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,17 +67,13 @@ fun ScheduleSheetContent(
             modifier = Modifier.padding(bottom = 8.dp),
         )
 
-        if (showDetails) {
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(),
-                thickness = DividerDefaults.Thickness,
-            )
+        if (!showDetails) return
 
-            if (schedule == null) {
-                EmptyState(R.string.schedule_no_upcoming_today)
-            } else {
-                ScheduleDetailsContent(schedule = schedule)
-            }
+        HorizontalDivider(Modifier.fillMaxWidth(), DividerDefaults.Thickness)
+
+        when (schedule) {
+            null -> EmptyState(R.string.no_schedule_found)
+            else -> ScheduleDetailsContent(schedule)
         }
     }
 }
@@ -86,20 +81,14 @@ fun ScheduleSheetContent(
 @Composable
 private fun ScheduleDetailsContent(schedule: Schedule) {
     var selectedDay by remember { mutableStateOf(DayOfWeek.fromToday()) }
-    var selectedDirection by remember { mutableStateOf<String?>(null) }
 
-    val directions =
+    val routes =
         remember(selectedDay, schedule) {
-            directionsForDay(selectedDay, schedule)
+            routesForDay(selectedDay, schedule)
         }
 
-    LaunchedEffect(selectedDay, directions) {
-        selectedDirection =
-            when {
-                directions.isEmpty() -> null
-                selectedDirection in directions -> selectedDirection
-                else -> directions.first()
-            }
+    var selectedRoute by remember(selectedDay, routes) {
+        mutableStateOf(routes.firstOrNull())
     }
 
     DaySelector(
@@ -107,29 +96,38 @@ private fun ScheduleDetailsContent(schedule: Schedule) {
         onSelect = { selectedDay = it },
     )
 
-    if (directions.isEmpty()) {
+    if (routes.isEmpty()) {
         EmptyState(R.string.schedule_none_running)
         return
     }
 
     RouteSelector(
-        directions = directions,
-        selectedDirection = selectedDirection,
-        onSelect = { selectedDirection = it },
+        routes = routes,
+        selectedRoute = selectedRoute,
+        onSelect = { selectedRoute = it },
     )
 
     HorizontalDivider(Modifier, DividerDefaults.Thickness)
 
     val times =
-        remember(selectedDay, selectedDirection, schedule) {
-            val dir = selectedDirection ?: return@remember emptyList()
+        remember(selectedDay, selectedRoute, schedule) {
+            val dir = selectedRoute ?: return@remember emptyList()
             consolidatedTimes(dir, selectedDay, schedule)
         }
 
-    ScheduleBody(
-        selectedDirection = selectedDirection,
-        times = times,
-    )
+    if (times.isEmpty()) {
+        EmptyState(R.string.no_schedule_found)
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        items(times, key = { it.busName + it.time + it.route }) { item ->
+            ScheduleTimeRow(time = item.time, busName = item.busName)
+        }
+    }
 }
 
 // Selectors
@@ -162,8 +160,8 @@ private fun DaySelector(
 
 @Composable
 private fun RouteSelector(
-    directions: List<String>,
-    selectedDirection: String?,
+    routes: List<String>,
+    selectedRoute: String?,
     onSelect: (String) -> Unit,
 ) {
     Row(
@@ -171,7 +169,7 @@ private fun RouteSelector(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        directions.forEach { dir ->
+        routes.forEach { dir ->
             RouteTab(
                 label =
                     stringResource(
@@ -181,7 +179,7 @@ private fun RouteSelector(
                             .replaceFirstChar { it.titlecase() },
                     ),
                 route = dir,
-                selectedRoute = selectedDirection,
+                selectedRoute = selectedRoute,
                 onRouteSelected = onSelect,
                 modifier = Modifier.weight(1f).padding(bottom = 8.dp),
             )
@@ -230,27 +228,6 @@ private fun RouteTab(
 }
 
 // List content
-
-@Composable
-private fun ScheduleBody(
-    selectedDirection: String?,
-    times: List<TimeInfo>,
-) {
-    when {
-        selectedDirection == null -> EmptyState(R.string.schedule_select_route)
-        times.isEmpty() -> EmptyState(R.string.schedule_no_upcoming_today)
-        else -> {
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(bottom = 24.dp),
-            ) {
-                items(times, key = { it.busName + it.time + it.direction }) { item ->
-                    ScheduleTimeRow(time = item.time, busName = item.busName)
-                }
-            }
-        }
-    }
-}
 
 @Composable
 private fun ScheduleTimeRow(
@@ -319,7 +296,10 @@ private fun busTagColor(
 
 // Data helpers
 
-private fun directionsForDay(
+/**
+ * Collects all unique directions (e.g. "NORTH", "WEST") running on a given day.
+ */
+private fun routesForDay(
     day: DayOfWeek,
     data: Schedule,
 ): List<String> {
@@ -336,11 +316,14 @@ private fun directionsForDay(
 
 private data class TimeInfo(
     val time: String,
-    val direction: String,
+    val route: String,
     val busName: String,
     val minutesOfDay: Int,
 )
 
+/**
+ * Parses a time string into minutes since midnight (or null if invalid).
+ */
 private fun parseMinutesOfDay(timeStr: String): Int? =
     runCatching {
         val t =
@@ -351,8 +334,11 @@ private fun parseMinutesOfDay(timeStr: String): Int? =
         t.hour * 60 + t.minute
     }.getOrNull()
 
+/**
+ * Flattens, filters, and sorts upcoming departures for one route on a given day.
+ */
 private fun consolidatedTimes(
-    direction: String,
+    route: String,
     day: DayOfWeek,
     data: Schedule,
 ): List<TimeInfo> {
@@ -369,8 +355,8 @@ private fun consolidatedTimes(
             if (pair.size <= 1) continue
 
             val timeStr = pair[0]
-            val dirStr = pair[1]
-            if (dirStr != direction) continue
+            val routeStr = pair[1]
+            if (routeStr != route) continue
 
             val minutes = parseMinutesOfDay(timeStr) ?: continue
             if (isToday && minutes < nowMinutes) continue
@@ -378,7 +364,7 @@ private fun consolidatedTimes(
             out +=
                 TimeInfo(
                     time = timeStr,
-                    direction = dirStr,
+                    route = routeStr,
                     busName = busName,
                     minutesOfDay = minutes,
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,10 +112,7 @@
     <string name="bus_speed">%.1f mph</string>
     <string name="no_location_warning">Unable to determine your location</string>
     <string name="bottom_sheet_peek_title">"Student Union Schedule"</string>
-    <string name="bottom_sheet_peek_subtitle">"Tap to view times"</string>
-    <string name="union_schedule">Union Schedule</string>
-    <string name="upcoming">"Upcoming"</string>
-    <string name="earlier">"Earlier Today"</string>
+    <string name="bottom_sheet_peek_subtitle">"Chasan stop available M–F, 7:00 AM – 5:30 PM"</string>
     <string name="schedule_select_route">Select a route</string>
     <string name="schedule_no_upcoming_today">No upcoming shuttles today</string>
     <string name="schedule_none_running">No shuttles running</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="bottom_sheet_peek_title">"Student Union Shuttle Arrivals"</string>
     <string name="bottom_sheet_peek_subtitle">"Chasan stop available M–F, 7:00 AM – 5:30 PM"</string>
     <string name="schedule_select_route">Select a route</string>
-    <string name="schedule_no_upcoming_today">No upcoming shuttles today</string>
+    <string name="no_schedule_found">No schedule found</string>
     <string name="schedule_none_running">No shuttles running</string>
     <string name="route_label_format">%1$s Route</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,11 +111,12 @@
     <string name="bus_number">Bus %1$s</string>
     <string name="bus_speed">%.1f mph</string>
     <string name="no_location_warning">Unable to determine your location</string>
-    <string name="bottom_sheet_peek_title">"Student Union Schedule"</string>
+    <string name="bottom_sheet_peek_title">"Student Union Shuttle Arrivals"</string>
     <string name="bottom_sheet_peek_subtitle">"Chasan stop available M–F, 7:00 AM – 5:30 PM"</string>
     <string name="schedule_select_route">Select a route</string>
     <string name="schedule_no_upcoming_today">No upcoming shuttles today</string>
     <string name="schedule_none_running">No shuttles running</string>
+    <string name="route_label_format">%1$s Route</string>
 
     <!-- Errors -->
     <string name="understand">I understand</string>


### PR DESCRIPTION
Fixes #132 

The MapScreen schedule used a modal bottom sheet with a custom peek that appeared draggable but only expanded on click, leading to a misleading interaction pattern.

Replaced the custom implementation with Material 3’s BottomSheetScaffold to provide native drag behavior and simplify the layout. Also includes minor naming refactors.

### Screenshots
<p float="left">
  <img width="300" alt="Bottom sheet partially expanded" src="https://github.com/user-attachments/assets/7fe1ed79-ae36-4191-b466-5cb061cdcef2" />
  <img width="300" alt="Bottom sheet fully expanded" src="https://github.com/user-attachments/assets/a5cc4d8f-df09-4af8-98d6-67ea8006e663" />
</p>

