### PR TITLE
Reconnect FCM and re-enable push notifications

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "659686770672",
-    "project_id": "shuttle-tracker-fcm",
-    "storage_bucket": "shuttle-tracker-fcm.appspot.com"
+    "project_number": "1029011361871",
+    "project_id": "shuttle-tracker-ef6fd",
+    "storage_bucket": "shuttle-tracker-ef6fd.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:659686770672:android:3ea865115ac069747f7f35",
+        "mobilesdk_app_id": "1:1029011361871:android:7c7e5dcfd22fbed40c5a3a",
         "android_client_info": {
           "package_name": "edu.rpi.shuttletracker"
         }
@@ -15,7 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyAlPiqjKd2mnYdI9zznPxoquEiYvs0OYuQ"
+          "current_key": "AIzaSyCUcRBNPqTRxAFdLpdkhp-vZEpDjHE7HiM"
         }
       ],
       "services": {

--- a/app/src/main/java/edu/rpi/shuttletracker/ShuttleTrackerApplication.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ShuttleTrackerApplication.kt
@@ -6,7 +6,6 @@ import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
 import edu.rpi.shuttletracker.util.notifications.Notifications
 import edu.rpi.shuttletracker.util.services.FirebaseService
-import edu.rpi.shuttletracker.util.workers.AnnouncementWorker
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -22,7 +21,7 @@ class ShuttleTrackerApplication :
 
         FirebaseService.retrieveToken()
 
-        AnnouncementWorker.startWork(this)
+//        AnnouncementWorker.startWork(this)
     }
 
     override val workManagerConfiguration: Configuration

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/MainActivity.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/MainActivity.kt
@@ -1,5 +1,6 @@
 package edu.rpi.shuttletracker.ui
 
+import android.app.NotificationManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -65,5 +66,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val nm = getSystemService(NotificationManager::class.java)
+        nm?.cancelAll()
     }
 }

--- a/app/src/main/java/edu/rpi/shuttletracker/util/notifications/NotificationReceiver.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/util/notifications/NotificationReceiver.kt
@@ -38,9 +38,9 @@ class NotificationReceiver : BroadcastReceiver() {
                     ) as NotificationManager
 
                 notificationManager.cancel(Notifications.ID_ANNOUNCEMENT)
-                goAsync {
-                    userPreferencesRepository.saveNotificationsRead(intent.getIntExtra("count", 0))
-                }
+//                goAsync {
+//                    userPreferencesRepository.saveNotificationsRead(intent.getIntExtra("count", 0))
+//                }
             }
         }
     }

--- a/app/src/main/java/edu/rpi/shuttletracker/util/notifications/Notifications.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/util/notifications/Notifications.kt
@@ -5,22 +5,24 @@ import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationChannelGroupCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.NotificationManagerCompat.IMPORTANCE_DEFAULT
-import edu.rpi.shuttletracker.R
 
 /**
  * Based on the notification generator for Tachiyomi
  * */
 object Notifications {
+    // Group
     private const val GROUP_TRACKER = "group_tracker"
-    const val CHANNEL_TRACKING_BUS = "tracking_bus_channel"
-    const val ID_TRACKING_BUS = 1
-
     private const val GROUP_ANNOUNCEMENTS = "group_announcements"
-    const val CHANNEL_ANNOUNCEMENT = "announcement_channel"
-    const val ID_ANNOUNCEMENT = 11
-
     private const val GROUP_DEPARTURES = "group_departures"
+
+    // Channels
+    const val CHANNEL_TRACKING_BUS = "tracking_bus_channel"
+    const val CHANNEL_ANNOUNCEMENT = "announcement_channel"
     const val CHANNEL_FIRING_DEPARTURES = "departure_alarm_channel"
+
+    // IDs
+    const val ID_TRACKING_BUS = 1
+    const val ID_ANNOUNCEMENT = 11
     const val ID_FIRING_DEPARTURE = 10000
 
     private val deprecatedChannels =
@@ -38,16 +40,8 @@ object Notifications {
         notificationManager.createNotificationChannelGroupsCompat(
             listOf(
                 buildNotificationChannelGroup(
-                    GROUP_TRACKER,
-                    context.getString(R.string.bus_tracker),
-                ),
-                buildNotificationChannelGroup(
                     GROUP_ANNOUNCEMENTS,
                     "Announcements",
-                ),
-                buildNotificationChannelGroup(
-                    GROUP_DEPARTURES,
-                    "Departures",
                 ),
             ),
         )
@@ -56,22 +50,10 @@ object Notifications {
         notificationManager.createNotificationChannelsCompat(
             listOf(
                 buildNotificationChannel(
-                    GROUP_TRACKER,
-                    CHANNEL_TRACKING_BUS,
-                    IMPORTANCE_DEFAULT,
-                    context.getString(R.string.tracker),
-                ),
-                buildNotificationChannel(
                     GROUP_ANNOUNCEMENTS,
                     CHANNEL_ANNOUNCEMENT,
                     IMPORTANCE_DEFAULT,
                     "Announcement",
-                ),
-                buildNotificationChannel(
-                    GROUP_DEPARTURES,
-                    CHANNEL_FIRING_DEPARTURES,
-                    IMPORTANCE_DEFAULT,
-                    "Firing departures",
                 ),
             ),
         )

--- a/app/src/main/java/edu/rpi/shuttletracker/util/services/FirebaseService.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/util/services/FirebaseService.kt
@@ -33,11 +33,19 @@ class FirebaseService : FirebaseMessagingService() {
         super.onMessageReceived(message)
 
         message.notification?.let {
-            it.body?.let { body -> sendNotification(body) }
+            val title = it.title
+            val body = it.body
+
+            if (title != null && body != null) {
+                sendNotification(title, body)
+            }
         }
     }
 
-    private fun sendNotification(body: String) {
+    private fun sendNotification(
+        title: String,
+        body: String,
+    ) {
         val notificationManager: NotificationManager =
             getSystemService(
                 NOTIFICATION_SERVICE,
@@ -48,7 +56,7 @@ class FirebaseService : FirebaseMessagingService() {
                 .Builder(
                     this,
                     Notifications.CHANNEL_ANNOUNCEMENT,
-                ).setContentTitle("FCM")
+                ).setContentTitle(title)
                 .setContentText(body)
                 .setSmallIcon(R.drawable.ic_stat_default)
                 .setContentIntent(NotificationReceiver.openMaps(this))

--- a/app/src/main/java/edu/rpi/shuttletracker/util/services/FirebaseService.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/util/services/FirebaseService.kt
@@ -1,7 +1,6 @@
 package edu.rpi.shuttletracker.util.services
 
 import android.app.NotificationManager
-import android.content.Context
 import androidx.core.app.NotificationCompat
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -41,7 +40,7 @@ class FirebaseService : FirebaseMessagingService() {
     private fun sendNotification(body: String) {
         val notificationManager: NotificationManager =
             getSystemService(
-                Context.NOTIFICATION_SERVICE,
+                NOTIFICATION_SERVICE,
             ) as NotificationManager
 
         val notificationBody =
@@ -52,7 +51,7 @@ class FirebaseService : FirebaseMessagingService() {
                 ).setContentTitle("FCM")
                 .setContentText(body)
                 .setSmallIcon(R.drawable.ic_stat_default)
-                .setContentIntent(NotificationReceiver.openAnnouncements(this))
+                .setContentIntent(NotificationReceiver.openMaps(this))
                 .build()
 
         notificationManager.notify(Notifications.ID_ANNOUNCEMENT, notificationBody)


### PR DESCRIPTION
Fixes the FCM part of #135

Reconnect FCM and temporarily disable announcement polling. Also temporarily allow clearing notification dot through opening the app.

Notifications can now be sent via Firebase Cloud Messaging campaigns (title + text).

example:
<img width="589" height="501" alt="image" src="https://github.com/user-attachments/assets/4d68be80-1c54-4069-8acf-3dd16912062a" />
