### PR TITLE
Automate Android signed releases (APK/AAB) + GitHub Release notes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,50 @@
+name: Build and Test
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+env:
+  MAIN_MODULE: app
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Create local.properties
+        if: ${{ secrets.MAPS_API_KEY != '' }}
+        run: |
+          echo "MAPS_API_KEY=${{ secrets.MAPS_API_KEY }}" > local.properties
+
+      - name: Ktlint Check
+        run: ./gradlew ktlintCheck
+
+      - name: Build Debug
+        run: ./gradlew :${{ env.MAIN_MODULE }}:assembleDebug
+
+      - name: Unit Tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Cleanup
+        if: always()
+        run: rm -f local.properties

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,6 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Create local.properties
-        if: ${{ secrets.MAPS_API_KEY != '' }}
         run: |
           echo "MAPS_API_KEY=${{ secrets.MAPS_API_KEY }}" > local.properties
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create local.properties
         run: |
-          echo "MAPS_API_KEY=${{ secrets.MAPS_API_KEY }}" >> local.properties
+          echo "MAPS_API_KEY=${{ secrets.MAPS_API_KEY }}" > local.properties
 
       - name: Build Release APK + AAB
         run: |
@@ -65,7 +65,6 @@ jobs:
           path: |
             ${{ steps.sign_apk.outputs.signedReleaseFile }}
             ${{ steps.sign_aab.outputs.signedReleaseFile }}
-        if: always()
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -75,6 +74,8 @@ jobs:
             ${{ steps.sign_apk.outputs.signedReleaseFile }}
             ${{ steps.sign_aab.outputs.signedReleaseFile }}
           generate_release_notes: true
+          draft: true
+          prerelease: true
 
       - name: Cleanup secrets
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Build & Publish Signed Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+env:
+  MAIN_MODULE: app
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Create local.properties
+        run: |
+          echo "MAPS_API_KEY=${{ secrets.MAPS_API_KEY }}" >> local.properties
+
+      - name: Build Release APK + AAB
+        run: |
+          ./gradlew :${{ env.MAIN_MODULE }}:assembleRelease :${{ env.MAIN_MODULE }}:bundleRelease
+
+      - name: Sign release APK
+        id: sign_apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: ${{ env.MAIN_MODULE }}/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+
+      - name: Sign release AAB
+        id: sign_aab
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: ${{ env.MAIN_MODULE }}/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+          alias: ${{ secrets.SIGNING_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+
+      - name: Upload artifacts (Actions)
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-build
+          path: |
+            ${{ steps.sign_apk.outputs.signedReleaseFile }}
+            ${{ steps.sign_aab.outputs.signedReleaseFile }}
+        if: always()
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ steps.sign_apk.outputs.signedReleaseFile }}
+            ${{ steps.sign_aab.outputs.signedReleaseFile }}
+          generate_release_notes: true
+
+      - name: Cleanup secrets
+        if: always()
+        run: rm -f local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("com.mikepenz.aboutlibraries.plugin")
     id("com.google.gms.google-services")
     id("org.jlleitschuh.gradle.ktlint")
+    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.ksp)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         </activity>
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/google_maps_key" />
+            android:value="${MAPS_API_KEY}" />
 
         <service
             android:name=".util.services.FirebaseService"

--- a/app/src/main/java/edu/rpi/shuttletracker/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/ui/settings/SettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.Contrast
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.RestartAlt
-import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -21,7 +20,6 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -125,23 +123,6 @@ fun SettingsScreen(
                 )
             }
         }
-    }
-}
-
-@Composable
-fun ColorBlindSettingItem(
-    colorBlindMode: Boolean,
-    updateColorBlindMode: (Boolean) -> Unit,
-) {
-    SettingsItem(
-        icon = Icons.Outlined.Visibility,
-        stringResource(R.string.color_blind_mode),
-        stringResource(R.string.color_blind_description),
-    ) {
-        Switch(
-            checked = colorBlindMode,
-            onCheckedChange = { updateColorBlindMode(it) },
-        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,8 +129,6 @@
     <string name="base_url">Base URL</string>
     <string name="change_url_warning">Changing the URL will restart the app and stop all running services</string>
     <string name="invalid_url">Invalid URL</string>
-    <string name="color_blind_description">More accessible shuttle icons</string>
-    <string name="color_blind_mode">Colorblind mode</string>
     <string name="current_meters">%1$d meters</string>
     <string name="libraries_used">Libraries used</string>
     <string name="dev_options_activated">Dev options activated</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
     dependencies {
         classpath(libs.google.services)
+        classpath(libs.secrets.gradle.plugin)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ retrofit = "3.0.0"
 
 room-runtime = "2.8.4"
 
+secrets-gradle-plugin = "2.0.1"
 work-runtime-ktx = "2.11.0"
 
 compose-bom = "2026.01.00"
@@ -98,6 +99,7 @@ play-services-maps = { module = "com.google.android.gms:play-services-maps", ver
 network-reponse = { module = "com.github.haroldadmin:NetworkResponseAdapter", version.ref = "network-respose" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 
+secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
 ui = { module = "androidx.compose.ui:ui" }
 
 [plugins]


### PR DESCRIPTION
Closes #146 

Adds GitHub Actions to automate Android CI and releases.
- PRs and main now run ktlint check, build, and unit tests
- Version tags (vX.Y.Z) automatically build and sign APK/AAB artifacts and publish a GitHub Release with autogenerated notes (draft for now).

Use Google’s Secrets Gradle Plugin to store Maps API key:
https://developers.google.com/maps/documentation/android-sdk/secrets-gradle-plugin