### PR TITLE
Add dev-mode shuttle inspector and polish adaptive Schedule/ETAs layout

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/core/ui/Errors.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/core/ui/Errors.kt
@@ -92,6 +92,7 @@ fun Error(
                 snackbarHostState.showSnackbar(
                     "$errorType: $errorBody",
                     actionLabel = primaryButtonText,
+                    withDismissAction = true,
                 )
 
             when (result) {

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/etas/EtasScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/etas/EtasScreen.kt
@@ -26,7 +26,10 @@ import edu.rpi.shuttletracker.feature.etas.utils.buildStopsWithEtas
  * */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun EtasScreen(viewModel: EtasViewModel = hiltViewModel()) {
+fun EtasScreen(
+    viewModel: EtasViewModel = hiltViewModel(),
+    showTitle: Boolean = true,
+) {
     val uiState by viewModel.etasUiState.collectAsStateWithLifecycle()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -62,6 +65,7 @@ fun EtasScreen(viewModel: EtasViewModel = hiltViewModel()) {
                 selectedRouteFilter = uiState.selectedRouteFilter,
                 onRouteFilterChange = viewModel::selectRouteFilter,
                 onStopClick = viewModel::selectStop,
+                showTitle = showTitle,
             )
 
             val stops =

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/etas/EtasViewModel.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/etas/EtasViewModel.kt
@@ -103,6 +103,18 @@ class EtasViewModel
                     var etas: Map<String, VehicleStopEta> = emptyMap()
                     var velocities: Map<String, VehicleVelocities> = emptyMap()
 
+                    // A live response this cycle proves whatever was wrong last cycle isn't
+                    // blocking us now - cleared here (not in readApiResponse) since that's shared
+                    // with the independent routes load, which shouldn't affect it.
+                    if (locationsResponse is NetworkResult.Success ||
+                        etasResponse is NetworkResult.Success ||
+                        velocitiesResponse is NetworkResult.Success
+                    ) {
+                        _etasUiState.update {
+                            it.copy(networkError = null, serverError = null, unknownError = null)
+                        }
+                    }
+
                     readApiResponse(locationsResponse) { locations = it }
                     readApiResponse(etasResponse) { etas = it }
                     readApiResponse(velocitiesResponse) { velocities = it }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/etas/components/StopEtaList.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/etas/components/StopEtaList.kt
@@ -52,12 +52,13 @@ fun StopEtaList(
     selectedRouteFilter: String?,
     onRouteFilterChange: (String?) -> Unit,
     onStopClick: (String) -> Unit,
+    showTitle: Boolean = true,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        EtasHeader()
+        EtasHeader(showTitle = showTitle)
 
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),
@@ -99,7 +100,7 @@ fun StopEtaList(
 }
 
 @Composable
-private fun EtasHeader() {
+private fun EtasHeader(showTitle: Boolean) {
     Column(
         modifier =
             Modifier
@@ -107,11 +108,13 @@ private fun EtasHeader() {
                 .padding(horizontal = 20.dp, vertical = 6.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
-            text = stringResource(R.string.nav_etas),
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(bottom = 4.dp),
-        )
+        if (showTitle) {
+            Text(
+                text = stringResource(R.string.nav_etas),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
 
         Text(
             text = stringResource(R.string.etas_subtitle),

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapContent.kt
@@ -46,6 +46,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import edu.rpi.shuttletracker.R
 import edu.rpi.shuttletracker.data.models.Stop
 import edu.rpi.shuttletracker.feature.map.components.AnnouncementStrip
+import edu.rpi.shuttletracker.feature.map.components.DeveloperVehicleView
 import kotlinx.coroutines.launch
 
 private val CampusCenter = LatLng(42.73068146020498, -73.67619731950525)
@@ -85,6 +86,8 @@ internal fun ShuttleMap(
             position = CameraPosition.fromLatLngZoom(CampusCenter, 14.3f)
         }
     var selectedStop by remember { mutableStateOf<Stop?>(null) }
+    var isDevPanelOpen by remember { mutableStateOf(false) }
+    var selectedDevVehicleId by remember { mutableStateOf<String?>(null) }
     val useDarkMap = uiState.themeMode.isDarkTheme(isSystemInDarkTheme())
     val fallbackRouteColor = MaterialTheme.colorScheme.primary
 
@@ -144,6 +147,7 @@ internal fun ShuttleMap(
                         vehicle = vehicle,
                         animationsEnabled = uiState.shuttleAnimationsEnabled,
                         rotationEnabled = uiState.shuttleRotationEnabled,
+                        selected = vehicle.id == selectedDevVehicleId,
                     )
                 }
             }
@@ -156,6 +160,7 @@ internal fun ShuttleMap(
                         vehicle = vehicle,
                         animationsEnabled = uiState.shuttleAnimationsEnabled,
                         rotationEnabled = uiState.shuttleRotationEnabled,
+                        selected = vehicle.id == selectedDevVehicleId,
                     )
                 }
             }
@@ -199,8 +204,36 @@ internal fun ShuttleMap(
                         contentDescription = stringResource(R.string.map_toggle_type),
                         onClick = onToggleMapTypeClick,
                     )
+                    if (uiState.isDevModeEnabled) {
+                        MapActionButton(
+                            icon = R.drawable.ic_bug_report,
+                            contentDescription = stringResource(R.string.dev_shuttle_inspector),
+                            onClick = { isDevPanelOpen = !isDevPanelOpen },
+                        )
+                    }
                 }
             }
+        }
+
+        if (uiState.isDevModeEnabled && isDevPanelOpen) {
+            DeveloperVehicleView(
+                vehicles = uiState.vehicles + uiState.fakeVehicles,
+                onClose = { isDevPanelOpen = false },
+                onZoomToVehicle = { vehicle ->
+                    selectedDevVehicleId = vehicle.id
+                    coroutineScope.launch {
+                        cameraPositionState.animate(
+                            CameraUpdateFactory.newLatLngZoom(vehicle.latLng(), 17f),
+                            durationMs = 1000,
+                        )
+                    }
+                },
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(contentPadding)
+                        .padding(16.dp),
+            )
         }
 
         // Schedule is reached via the bottom nav bar now, so Recenter is the map's only FAB.

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapMarkers.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapMarkers.kt
@@ -72,13 +72,16 @@ internal fun StopMarker(
 /**
  * A shuttle's marker, colored by [Vehicle.routeName] (falls back to the last known color for a
  * while if the route briefly drops out, so the marker doesn't flash gray). Works for real vehicles
- * and fake ones alike - both are just [Vehicle] instances.
+ * and fake ones alike - both are just [Vehicle] instances. [selected] opens the info window
+ * automatically (used by the dev-mode shuttle inspector to jump to a specific vehicle), separate
+ * from the normal tap-to-open behavior.
  * */
 @Composable
 internal fun VehicleMarker(
     vehicle: Vehicle,
     animationsEnabled: Boolean,
     rotationEnabled: Boolean,
+    selected: Boolean = false,
 ) {
     val context = LocalContext.current
     val target = vehicle.latLng()
@@ -88,6 +91,10 @@ internal fun VehicleMarker(
         rememberUpdatedMarkerState(
             position = LatLng(latitude.value.toDouble(), longitude.value.toDouble()),
         )
+
+    LaunchedEffect(selected) {
+        if (selected) markerState.showInfoWindow()
+    }
 
     LaunchedEffect(target, animationsEnabled) {
         if (animationsEnabled) {

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsScreen.kt
@@ -155,7 +155,11 @@ fun MapsScreen(
                             .fillMaxSize()
                             .padding(contentPadding),
                     ) {
-                        ScheduleScreen(viewModel = scheduleViewModel, showTitle = !useNavigationRail)
+                        ScheduleScreen(
+                            viewModel = scheduleViewModel,
+                            showTitle = !useNavigationRail,
+                            isWideLayout = useNavigationRail,
+                        )
                     }
             }
         }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsScreen.kt
@@ -144,7 +144,9 @@ fun MapsScreen(
                             .fillMaxSize()
                             .padding(contentPadding),
                     ) {
-                        EtasScreen(viewModel = etasViewModel)
+                        // The rail already labels the selected tab "ETAs", so the in-content title
+                        // would just repeat it - only show it with a bottom bar instead.
+                        EtasScreen(viewModel = etasViewModel, showTitle = !useNavigationRail)
                     }
 
                 MainTab.Schedule ->
@@ -153,7 +155,7 @@ fun MapsScreen(
                             .fillMaxSize()
                             .padding(contentPadding),
                     ) {
-                        ScheduleScreen(viewModel = scheduleViewModel)
+                        ScheduleScreen(viewModel = scheduleViewModel, showTitle = !useNavigationRail)
                     }
             }
         }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
@@ -220,6 +220,14 @@ class MapsViewModel
                     }
                 }.launchIn(viewModelScope)
 
+            userPreferences
+                .getDevOptions()
+                .onEach { devOptionsEnabled ->
+                    _mapsUiState.update {
+                        it.copy(isDevModeEnabled = devOptionsEnabled)
+                    }
+                }.launchIn(viewModelScope)
+
             combine(
                 userPreferences.getDevOptions(),
                 userPreferences.getSimulateAnnouncements(),
@@ -307,4 +315,5 @@ data class MapsUiState(
     val mapType: MapType = MapType.NORMAL,
     val shuttleAnimationsEnabled: Boolean = false,
     val shuttleRotationEnabled: Boolean = true,
+    val isDevModeEnabled: Boolean = false,
 )

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
@@ -93,6 +93,18 @@ class MapsViewModel
                     var etas: Map<String, VehicleStopEta> = emptyMap()
                     var velocities: Map<String, VehicleVelocities> = emptyMap()
 
+                    // A live response this cycle proves whatever was wrong last cycle isn't
+                    // blocking us now - cleared here (not in readApiResponse) since that's shared
+                    // with the independent announcement/routes loads, which shouldn't affect it.
+                    if (locationsResponse is NetworkResult.Success ||
+                        etasResponse is NetworkResult.Success ||
+                        velocitiesResponse is NetworkResult.Success
+                    ) {
+                        _mapsUiState.update {
+                            it.copy(networkError = null, serverError = null, unknownError = null)
+                        }
+                    }
+
                     readApiResponse(locationsResponse) { locations = it }
                     readApiResponse(etasResponse) { etas = it }
                     readApiResponse(velocitiesResponse) { velocities = it }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/components/DeveloperVehicleView.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/components/DeveloperVehicleView.kt
@@ -1,0 +1,149 @@
+package edu.rpi.shuttletracker.feature.map.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import edu.rpi.shuttletracker.R
+import edu.rpi.shuttletracker.data.models.Vehicle
+
+/**
+ * Dev-mode-only panel listing every currently known [Vehicle] (real and fake), for inspecting
+ * live shuttle data without needing a debugger - see issue #137. [onZoomToVehicle] both pans the
+ * map camera to that vehicle and opens its marker's info window (wired up by the caller, since
+ * both the camera and the markers live in [edu.rpi.shuttletracker.feature.map.MapContent]).
+ * */
+@Composable
+internal fun DeveloperVehicleView(
+    vehicles: List<Vehicle>,
+    onClose: () -> Unit,
+    onZoomToVehicle: (Vehicle) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .width(300.dp)
+                .background(
+                    MaterialTheme.colorScheme.surface.copy(alpha = 0.97f),
+                    shape = MaterialTheme.shapes.medium,
+                ).padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.dev_shuttles_title, vehicles.size),
+                style = MaterialTheme.typography.titleSmall,
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            IconButton(onClick = onClose, modifier = Modifier.size(32.dp)) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_close),
+                    contentDescription = stringResource(R.string.close),
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+
+        HorizontalDivider()
+
+        if (vehicles.isEmpty()) {
+            Text(
+                text = stringResource(R.string.dev_no_active_shuttles),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        } else {
+            Column(
+                modifier =
+                    Modifier
+                        .heightIn(max = 320.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                vehicles.sortedBy { it.name }.forEach { vehicle ->
+                    DevVehicleCard(vehicle = vehicle, onZoomClick = { onZoomToVehicle(vehicle) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DevVehicleCard(
+    vehicle: Vehicle,
+    onZoomClick: () -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(
+                    MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f),
+                    shape = RoundedCornerShape(8.dp),
+                ).padding(8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.vehicle_number, vehicle.name),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(Modifier.weight(1f))
+
+            IconButton(onClick = onZoomClick, modifier = Modifier.size(28.dp)) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_my_location),
+                    contentDescription = stringResource(R.string.dev_zoom_to_shuttle),
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+
+        DevInfoRow(
+            label = stringResource(R.string.dev_route),
+            value = vehicle.routeName ?: stringResource(R.string.dev_unknown),
+        )
+        DevInfoRow(
+            label = stringResource(R.string.dev_speed),
+            value = stringResource(R.string.vehicle_speed, vehicle.speedMph),
+        )
+        DevInfoRow(
+            label = stringResource(R.string.dev_current_stop),
+            value = vehicle.currentStop ?: stringResource(R.string.dev_none),
+        )
+    }
+}
+
+@Composable
+private fun DevInfoRow(
+    label: String,
+    value: String,
+) {
+    Text(
+        text = "$label: $value",
+        style = MaterialTheme.typography.bodySmall,
+    )
+}

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/ScheduleScreen.kt
@@ -18,7 +18,10 @@ import edu.rpi.shuttletracker.feature.schedule.components.ScheduleContent
 
 /** The Schedule tab: fetches routes/schedule via [ScheduleViewModel] and renders them with [ScheduleContent]. */
 @Composable
-fun ScheduleScreen(viewModel: ScheduleViewModel = hiltViewModel()) {
+fun ScheduleScreen(
+    viewModel: ScheduleViewModel = hiltViewModel(),
+    showTitle: Boolean = true,
+) {
     val uiState by viewModel.scheduleUiState.collectAsStateWithLifecycle()
     var selectedRoute by rememberSaveable { mutableStateOf<String?>(null) }
 
@@ -45,6 +48,7 @@ fun ScheduleScreen(viewModel: ScheduleViewModel = hiltViewModel()) {
                 routesByName = uiState.routes,
                 selectedRoute = selectedRoute,
                 onSelectedRouteChange = { selectedRoute = it },
+                showTitle = showTitle,
             )
         }
     }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/ScheduleScreen.kt
@@ -21,6 +21,7 @@ import edu.rpi.shuttletracker.feature.schedule.components.ScheduleContent
 fun ScheduleScreen(
     viewModel: ScheduleViewModel = hiltViewModel(),
     showTitle: Boolean = true,
+    isWideLayout: Boolean = false,
 ) {
     val uiState by viewModel.scheduleUiState.collectAsStateWithLifecycle()
     var selectedRoute by rememberSaveable { mutableStateOf<String?>(null) }
@@ -49,6 +50,7 @@ fun ScheduleScreen(
                 selectedRoute = selectedRoute,
                 onSelectedRouteChange = { selectedRoute = it },
                 showTitle = showTitle,
+                isWideLayout = isWideLayout,
             )
         }
     }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
@@ -73,6 +73,7 @@ fun ScheduleContent(
     selectedRoute: String?,
     onSelectedRouteChange: (String) -> Unit,
     showTitle: Boolean = true,
+    isWideLayout: Boolean = false,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -94,6 +95,7 @@ fun ScheduleContent(
                     routesByName = routesByName,
                     selectedRoute = selectedRoute,
                     onSelectedRouteChange = onSelectedRouteChange,
+                    isWideLayout = isWideLayout,
                 )
         }
     }
@@ -131,6 +133,7 @@ private fun ScheduleDetailsContent(
     routesByName: Map<String, Route>,
     selectedRoute: String?,
     onSelectedRouteChange: (String) -> Unit,
+    isWideLayout: Boolean,
 ) {
     var selectedDay by remember { mutableStateOf(DayOfWeek.fromToday()) }
 
@@ -146,21 +149,48 @@ private fun ScheduleDetailsContent(
             else -> null
         }
 
-    DaySelector(
-        selectedDay = selectedDay,
-        onSelect = { selectedDay = it },
-    )
+    if (isWideLayout) {
+        // Wide enough that the two selectors don't need to compete for the same row - saves the
+        // vertical space the stacked layout would otherwise spend on a second row.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DaySelector(
+                selectedDay = selectedDay,
+                onSelect = { selectedDay = it },
+                modifier = Modifier.weight(1f),
+            )
+
+            if (routes.isNotEmpty()) {
+                RouteSelector(
+                    routes = routes,
+                    selectedRoute = activeRoute,
+                    onSelect = onSelectedRouteChange,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    } else {
+        DaySelector(
+            selectedDay = selectedDay,
+            onSelect = { selectedDay = it },
+        )
+    }
 
     if (routes.isEmpty()) {
         EmptyState(R.string.schedule_none_running)
         return
     }
 
-    RouteSelector(
-        routes = routes,
-        selectedRoute = activeRoute,
-        onSelect = onSelectedRouteChange,
-    )
+    if (!isWideLayout) {
+        RouteSelector(
+            routes = routes,
+            selectedRoute = activeRoute,
+            onSelect = onSelectedRouteChange,
+        )
+    }
 
     HorizontalDivider(Modifier, DividerDefaults.Thickness)
 
@@ -228,13 +258,14 @@ private fun ScheduleDetailsContent(
 private fun DaySelector(
     selectedDay: DayOfWeek,
     onSelect: (DayOfWeek) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val scrollState = rememberScrollState()
     val days = DayOfWeek.entries
 
     SingleChoiceSegmentedButtonRow(
         modifier =
-            Modifier
+            modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .horizontalScroll(scrollState),
@@ -255,9 +286,10 @@ private fun RouteSelector(
     routes: List<String>,
     selectedRoute: String?,
     onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier.fillMaxWidth(0.9f),
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(0.9f),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
@@ -154,7 +154,6 @@ private fun ScheduleDetailsContent(
         // vertical space the stacked layout would otherwise spend on a second row.
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             DaySelector(
@@ -168,7 +167,7 @@ private fun ScheduleDetailsContent(
                     routes = routes,
                     selectedRoute = activeRoute,
                     onSelect = onSelectedRouteChange,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).padding(horizontal = 12.dp),
                 )
             }
         }

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/schedule/components/ScheduleContent.kt
@@ -72,12 +72,13 @@ fun ScheduleContent(
     routesByName: Map<String, Route>,
     selectedRoute: String?,
     onSelectedRouteChange: (String) -> Unit,
+    showTitle: Boolean = true,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        ScheduleHeader()
+        ScheduleHeader(showTitle = showTitle)
 
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),
@@ -99,7 +100,7 @@ fun ScheduleContent(
 }
 
 @Composable
-private fun ScheduleHeader() {
+private fun ScheduleHeader(showTitle: Boolean) {
     Column(
         modifier =
             Modifier
@@ -107,11 +108,13 @@ private fun ScheduleHeader() {
                 .padding(horizontal = 20.dp, vertical = 6.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(
-            text = stringResource(R.string.schedule_title),
-            style = MaterialTheme.typography.titleLarge,
-            modifier = Modifier.padding(bottom = 4.dp),
-        )
+        if (showTitle) {
+            Text(
+                text = stringResource(R.string.schedule_title),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
 
         Text(
             text = stringResource(R.string.schedule_subtitle),

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M480,536L284,732Q270,746 249,745.5Q228,745 213,730Q199,715 199,694.5Q199,674 213,660L410,464L213,268Q199,254 199,233Q199,212 213,197.5Q227,183 248,183Q269,183 284,197L480,394L676,197Q690,183 711,183Q732,183 746,197.5Q761,212 761,233Q761,254 746,268L550,464L746,660Q761,674 761,695Q761,716 746,730.5Q732,745 711,745Q690,745 676,731L480,536Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,18 @@
     <string name="schedule_none_running">No shuttles running</string>
     <string name="route_label_format">%1$s Route</string>
 
+    <!-- Dev-mode shuttle inspector -->
+    <string name="dev_shuttle_inspector">Shuttle inspector</string>
+    <string name="dev_shuttles_title">Active Shuttles (%1$d)</string>
+    <string name="dev_no_active_shuttles">No active shuttles</string>
+    <string name="dev_zoom_to_shuttle">Zoom to shuttle</string>
+    <string name="dev_route">Route</string>
+    <string name="dev_speed">Speed</string>
+    <string name="dev_current_stop">Current stop</string>
+    <string name="dev_unknown">Unknown</string>
+    <string name="dev_none">None</string>
+    <string name="close">Close</string>
+
     <!-- ETAs tab -->
     <string name="etas_subtitle">Tap a stop to see every shuttle\'s live arrival time.</string>
     <string name="etas_route_all">All Routes</string>


### PR DESCRIPTION
Closes #137 

## Summary
- Add a dev-mode-only shuttle inspector panel on the map screen: lists every
  active vehicle (real + fake) with name, route, speed, and current stop; tapping one
  pans the camera to it and opens its marker's info window. Wires up the velocities
  endpoint data that was already merged in but not exposed anywhere.
- Hide the redundant "ETAs"/"Schedule" title on those tabs when the navigation rail is
  showing, since the rail already labels the selected tab.
- On wide layouts, combine the Schedule tab's day selector and route selector into a
  single row instead of stacking them, reclaiming vertical space; fix the spacing so
  the route selector isn't flush against the screen edge.
- Add a Close action to the network/server/unknown error snackbar (previously only
  Retry or swipe-to-dismiss), and fix the error state so it actually clears once
  polling succeeds again instead of staying stuck until a manual retry.