### PR TITLE
Add stale-data indicator on map, fix offline caching masking real outages

### DIFF
--- a/app/src/main/java/edu/rpi/shuttletracker/app/di/NetworkModule.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/app/di/NetworkModule.kt
@@ -37,7 +37,12 @@ object NetworkModule {
         Interceptor { chain ->
             var request = chain.request()
 
-            if (!context.hasNetwork()) {
+            if (request.url.pathSegments.lastOrNull() in LivePolledPaths) {
+                // Vehicle locations/etas/velocities are meaningless once stale - never write them to
+                // the disk cache and never serve them from it, so going offline fails outright
+                // instead of silently replaying old vehicle positions as if they were live.
+                request = request.newBuilder().header("Cache-Control", "no-store").build()
+            } else if (!context.hasNetwork()) {
                 // 2 week cache for offline
                 request =
                     request
@@ -98,3 +103,6 @@ object NetworkModule {
     @Singleton
     fun provideShuttleApi(retrofit: Retrofit): ShuttleApi = retrofit.create(ShuttleApi::class.java)
 }
+
+/** Endpoints that poll live vehicle state - these must never be cached or replayed while stale. */
+private val LivePolledPaths = setOf("locations", "etas", "velocities")

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapContent.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapContent.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -184,11 +183,19 @@ internal fun ShuttleMap(
                 modifier = Modifier.fillMaxWidth(),
             )
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
-            ) {
-                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            // A Box with independently-aligned children, not a Row with Arrangement.SpaceBetween -
+            // the chip can disappear/reappear on its own schedule, and SpaceBetween would shove the
+            // FAB stack over to the start edge whenever it's the Row's only remaining child.
+            Box(modifier = Modifier.fillMaxWidth()) {
+                LastUpdatedChip(
+                    updatedAt = uiState.vehiclesUpdatedAt,
+                    modifier = Modifier.align(Alignment.TopStart),
+                )
+
+                Column(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
                     MapActionButton(
                         icon = R.drawable.ic_settings,
                         contentDescription = stringResource(R.string.map_open_settings),

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapMarkers.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapMarkers.kt
@@ -4,12 +4,16 @@ import androidx.annotation.DrawableRes
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,6 +41,8 @@ import edu.rpi.shuttletracker.data.models.Vehicle
 import edu.rpi.shuttletracker.feature.map.components.getVehicleMarkerDescriptor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.Instant
 
 /** A stop's circle on the map. The actual [Marker] is invisible (`alpha = 0f`) - it only exists to catch taps and show the stop's name in an info window. */
 @Composable
@@ -174,6 +180,71 @@ internal fun MapActionButton(
         elevation = ButtonDefaults.buttonElevation(defaultElevation = 10.dp),
     ) {
         Icon(painterResource(icon), contentDescription)
+    }
+}
+
+private val FLASH_WINDOW: Duration = Duration.ofSeconds(3)
+private val STALE_THRESHOLD: Duration = Duration.ofSeconds(30)
+
+/**
+ * A translucent pill floating over the map opposite the [MapActionButton] stack - hidden almost
+ * all the time, and never shown at all as long as polling keeps succeeding. It only appears once
+ * [updatedAt] hasn't advanced in [STALE_THRESHOLD] (timed from first composition if a poll has
+ * never succeeded yet), and then, once a poll finally does succeed again, flashes "Updated" for
+ * [FLASH_WINDOW] before disappearing. A routine successful poll that was never stale never
+ * triggers the flash - only a *recovery* from a stale state does.
+ * */
+@Composable
+internal fun LastUpdatedChip(
+    updatedAt: Instant?,
+    modifier: Modifier = Modifier,
+) {
+    val mountedAt = remember { Instant.now() }
+    var now by remember { mutableStateOf(Instant.now()) }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1_000L)
+            now = Instant.now()
+        }
+    }
+
+    val isStale = Duration.between(updatedAt ?: mountedAt, now) >= STALE_THRESHOLD
+    var wasStale by remember { mutableStateOf(false) }
+    var showRecoveryFlash by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isStale) {
+        if (isStale) wasStale = true
+    }
+
+    LaunchedEffect(updatedAt) {
+        if (updatedAt != null && wasStale) {
+            wasStale = false
+            showRecoveryFlash = true
+            delay(FLASH_WINDOW.toMillis())
+            showRecoveryFlash = false
+        }
+    }
+
+    val text =
+        when {
+            showRecoveryFlash -> "Updated"
+            isStale -> "Not updated in ${Duration.between(updatedAt ?: mountedAt, now).seconds}s"
+            else -> null
+        } ?: return
+    val (containerColor, contentColor) = mapButtonColors()
+
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(50),
+        color = containerColor.copy(alpha = 0.55f),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = contentColor,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        )
     }
 }
 

--- a/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
+++ b/app/src/main/java/edu/rpi/shuttletracker/feature/map/MapsViewModel.kt
@@ -101,7 +101,12 @@ class MapsViewModel
                         velocitiesResponse is NetworkResult.Success
                     ) {
                         _mapsUiState.update {
-                            it.copy(networkError = null, serverError = null, unknownError = null)
+                            it.copy(
+                                networkError = null,
+                                serverError = null,
+                                unknownError = null,
+                                vehiclesUpdatedAt = Instant.now(),
+                            )
                         }
                     }
 
@@ -319,6 +324,7 @@ data class MapsUiState(
     val routes: Map<String, Route> = emptyMap(),
     val announcements: List<Announcement> = emptyList(),
     val announcementsUpdatedAt: Instant? = null,
+    val vehiclesUpdatedAt: Instant? = null,
     val simulateAnnouncements: Boolean = false,
     val networkError: NetworkError.Connectivity? = null,
     val serverError: NetworkError.Http? = null,

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -72,8 +72,8 @@ Open the **local.properties** in your project level directory, and then add the 
 
 ## 4. Running the Virtual Android Device
 1. In Android Studio, open the **Device Manager**, click the **+** button, and select **Create Virtual Device**.
-2. Choose **Pixel 5**. When prompted to select a system image, choose **API level 31 (Android S)**.
-3. Select the Pixel 5 emulator as your run configuration.
+2. Choose **Pixel 8**. When prompted to select a system image, choose **API level 34 (Android 14)** - specifically the image with the **Play Store** icon next to it, not a plain "Google APIs" image. The app uses Firebase push notifications, which need real Google Play Services to deliver correctly, and only the Play Store images include that.
+3. Select the Pixel 8 emulator as your run configuration.
 4. Click **Run**.
 
 After completing these steps, the virtual Android device should launch and Google Maps should load correctly.

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -19,8 +19,7 @@ To send yourself a test notification:
 
 1. Run a debug build and let the app start once (this registers the device and generates an FCM token).
 2. Check Logcat for the tag `FCM_TOKEN` - `FirebaseService.onNewToken()` logs it on debug builds only.
-3. In the [Firebase Console](https://console.firebase.google.com/), open this project → **Engage** →
-   **Messaging** → **New campaign** → **Notifications**.
+3. In the [Firebase Console](https://console.firebase.google.com/), open this project → **Messaging** → **New campaign** → **Notifications**.
 4. Under **Target**, choose **Send test message** and paste in the token from step 2. This sends the
    notification to just your device instead of every install.
 5. Send it. If the app is backgrounded or not running, Android displays it automatically using the manifest's


### PR DESCRIPTION
Closes #142 

## Summary
- Adds a "last updated" chip to the map screen (top-left). Hidden during normal polling; only appears if data hasn't refreshed in 30+ seconds, then flashes "Updated" once it recovers. Addresses #142, but as a hide-unless-stale indicator rather than the always-on timestamp the issue described.
- Fixes `locations`/`etas`/`velocities` silently serving stale cached data (up to 2 weeks old) when offline instead of failing. They now always set `Cache-Control: no-store`, so a dropped connection fails honestly instead of looking like a successful poll.
